### PR TITLE
auto fit table to page width

### DIFF
--- a/.Rbuildignore
+++ b/.Rbuildignore
@@ -1,0 +1,2 @@
+^.*\.Rproj$
+^\.Rproj\.user$

--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,4 @@
+.Rproj.user
+.Rhistory
+.RData
+.Ruserdata

--- a/R/dump_df_mat_to_file.R
+++ b/R/dump_df_mat_to_file.R
@@ -95,7 +95,7 @@ dump_df_mat_to_file <- function(out,
  # Align it - 9.17.20: Modified the alignment
   # https://stackoverflow.com/questions/57175351/flextable-autofit-in-a-rmarkdown-to-word-doc-causes-table-to-go-outside-page-mar
   #myft <- autofit(myft)
-  myft <- flextable::set_table_properties(myft, layout = 'autofit')
+  myft <- flextable::set_table_properties(myft, layout = 'autofit', width = 1)
 
 
 


### PR DESCRIPTION
Modified the dump_df_mat_to_file function to automatically fit tables to page width in word. 